### PR TITLE
refactor: remove IRequest and add semantic result types with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 ﻿# 📦 Changelog — Mediary
 
+## [v0.3.0] - 2025-07-27
+
+### ⚠️ Breaking Changes
+
+* ❌ **Removed `IRequest` (non-generic)**
+
+  * Eliminated support for `IRequest`, `IRequestHandler<TRequest>`, and `IRequestPipelineBehavior<TRequest>`.
+  * All requests must now implement `IRequest<TResponse>`.
+  * Pipeline and handler contracts were updated to support only the generic form.
+
+* 🧼 **Removed legacy extensions**
+
+  * Extensions like `ExecuteAsync<TRequest>()` were removed along with support for non-generic requests.
+
+* 🧹 **Simplified `IRequestDispatcher`**
+
+  * Now only contains:
+
+    ```csharp
+    Task<TResponse> DispatchAsync<TResponse, TRequest>(TRequest request);
+    ```
+  * The previous `ExecuteAsync` overloads were removed to streamline the interface.
+
+---
+
+### ✨ New Features
+
+* **Built-in Semantic Result Types** (under `Mediary.Core.Results`)
+
+  * Introduced lightweight `readonly struct`s for non-data responses:
+
+    * [`Unit`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Unit.cs)
+    * [`Success`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Success.cs)
+    * [`Created`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Created.cs)
+    * [`Updated`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Updated.cs)
+    * [`Deleted`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Deleted.cs)
+  * These types can be used as `TResponse` for commands that don’t return data, improving semantic clarity (e.g. `IRequest<Deleted>`).
+
+* **Static `Result` helper**
+
+  * Added `Result.Unit`, `Result.Created`, etc. for more fluent return values.
+
 ## [v0.2.0] - 2025-07-17
 
 ### ✨ Features

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 **Mediary** is a minimal, open-source request/response dispatcher for .NET —  
 inspired by MediatR, but built from scratch with **no external dependencies**.
 
-It provides clean request handling, extensible pipeline behaviors, and a flexible DI-friendly architecture — all without relying on third-party libraries.
+Clean request handling, extensible pipeline behaviors, and a DI-friendly architecture — all with zero external dependencies.
 
 [![Build](https://github.com/facus26/Mediary/actions/workflows/build-test-coverage.yml/badge.svg)](https://github.com/facus26/Mediary/actions/workflows/build-test-coverage.yml)
 [![codecov](https://codecov.io/gh/facus26/Mediary/branch/main/graph/badge.svg)](https://codecov.io/gh/facus26/Mediary)
@@ -28,6 +28,25 @@ It focuses on **performance**, **clarity**, and **developer control**, while mai
 
 ---
 
+## 🧭 Table of Contents
+
+- [Installation](#-installation)
+- [Features](#-features)
+- [Usage](#-usage)
+- [Dependency Injection](#-dependency-injection)
+  - [Option 1 — Auto-registration (Recommended)](#-option-1--auto-registration-recommended)
+  - [Option 2 — Semi-manual (Builder API)](#-option-2--semi-manual-builder-api)
+  - [Option 3 — Fully manual](#-option-3--fully-manual)
+- [Built-in Behaviors](#-built-in-behaviors)
+  - [Register pipeline behaviors globally](#-register-pipeline-behaviors-globally)
+- [Handling Commands Without Return Values](#-handling-commands-without-return-values)
+    - [Built-in Result Types](#-built-in-result-types)
+- [Core Interfaces](#-core-interfaces)
+- [Aliases](#-aliases) 
+- [Request Metadata](#-request-metadata)
+
+---
+
 ## 📦 Installation
 
 You can install **Mediary** via NuGet:
@@ -44,12 +63,14 @@ Or via the NuGet UI in Visual Studio by searching for **Mediary**.
 
 ## 🚀 Features
 
-* ✅ Async request handling via `IRequest<TResponse>` / `IRequest`
-* ✅ Built-in dispatcher (`IRequestDispatcher`)
-* ✅ Middleware support (`IRequestPipelineBehavior`)
+* ✅ Async request handling via [`IRequest<TResponse>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/IRequest.cs)
+* ✅ Handler support via [`IRequestHandler<TResponse, TRequest>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/IRequestHandler.cs)
+* ✅ Semantic result types: [`Unit`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Unit.cs), [`Success`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Success.cs), [`Created`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Created.cs), [`Updated`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Updated.cs), [`Deleted`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Deleted.cs)
+* ✅ Dispatcher support via [`IRequestDispatcher`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Dispatcher/IRequestDispatcher.cs)
+* ✅ Middleware support [`IRequestPipelineBehavior<TResponse, TRequest>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Pipeline/IRequestPipelineBehavior.cs)
 * ✅ Generic and specific pipeline registration
-* ✅ Optional `[RequestInfo]` metadata for descriptive logging and tooling
-
+* ✅ Optional [`[RequestInfo]`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Attributes/RequestInfoAttribute.cs) metadata for descriptive logging and tooling
+* ✅ Aliases for semantic intent: [`ICommand<TResponse>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/ICommand.cs), [`IQuery<TResponse>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/IQuery.cs)
 
 ---
 
@@ -84,7 +105,7 @@ public class PlanService
         _dispatcher = dispatcher;
 
     public Task<List<PlanDto>> GetPlansAsync() =>
-        _dispatcher.ExecuteAsync<GetAllPlansQuery, List<PlanDto>>(new GetAllPlansQuery());
+        _dispatcher.DispatchAsync<GetAllPlansQuery, List<PlanDto>>(new GetAllPlansQuery());
 }
 ```
 
@@ -105,9 +126,9 @@ services.AddMediary()
 
 This will:
 
-* Register the `IRequestDispatcher`
-* Scan and register all `IRequestHandler<>` and `IRequestHandler<,>`
-* Scan and register all `IRequestPipelineBehavior<>` and `IRequestPipelineBehavior<,>`
+* Register the [`IRequestDispatcher`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Dispatcher/IRequestDispatcher.cs)
+* Scan and register all [`IRequestHandler<,>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/IRequestHandler.cs)
+* Scan and register all [`IRequestPipelineBehavior<,>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Pipeline/IRequestPipelineBehavior.cs)
 
 ### 🔧 Option 2 — Semi-manual (Builder API)
 
@@ -115,9 +136,7 @@ If you prefer full control but want to use the builder pattern:
 
 ```csharp
 services.AddMediary()
-    .AddRequestHandler<GetAllPlansQuery, GetAllPlansHandler>()
     .AddRequestHandler<List<PlanDto>, GetAllPlansQuery, GetAllPlansHandler>()
-    .AddPipelineBehaviors<GetAllPlansQuery, LoggingBehavior<GetAllPlansQuery>>()
     .AddPipelineBehaviors<List<PlanDto>, GetAllPlansQuery, LoggingBehavior<List<PlanDto>, GetAllPlansQuery>>();
 ```
 
@@ -143,10 +162,10 @@ This gives you **maximum flexibility** and full control over dependency injectio
 
 ## 🔍 Built-in Behaviors
 
-- [`LoggingBehavior<TResponse, TRequest>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Pipeline/Behaviors/LoggingBehavior.cs)  
-    Logs the start and end of a request using `ILogger`.
-- [`PerformanceBehavior<TResponse, TRequest>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Pipeline/Behaviors/PerformanceBehavior.cs)  
-    Measures and logs execution time of each request.
+| Interface | Description |
+|----------|-------------|
+| [`LoggingBehavior<TResponse, TRequest>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Pipeline/Behaviors/LoggingBehavior.cs) | Logs the start and end of a request using `ILogger`. |
+| [`PerformanceBehavior<TResponse, TRequest>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Pipeline/Behaviors/PerformanceBehavior.cs) | Measures and logs execution time of each request. |
 
 ### ✅ Register pipeline behaviors globally
 
@@ -171,6 +190,59 @@ This will ensure that both behaviors are applied to all requests automatically.
 
 ---
 
+## ✅ Core Interfaces
+
+| Interface | Description |
+|----------|-------------|
+| [`IRequest<TResponse>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/IRequest.cs) | Base request contract used for dispatching |
+| [`IRequestHandler<TResponse, TRequest>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/IRequestHandler.cs) | Handles a specific request and returns a response |
+| [`IRequestPipelineBehavior<TResponse, TRequest>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Pipeline/IRequestPipelineBehavior.cs) | Defines pipeline logic before/after the handler |
+| [`IRequestDispatcher`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Dispatcher/IRequestDispatcher.cs) | Responsible for dispatching requests through the pipeline |
+
+---
+
+## ⚙️ Handling Commands Without Return Values
+
+Mediary uses a single interface: [`IRequest<TResponse>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/IRequest.cs).  
+When you don’t need to return data from a command, you can use semantic result types to indicate intent:
+
+### ✅ Built-in Result Types
+
+| Type | Purpose |
+|------|---------|
+| [`Unit`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Unit.cs) | Used when no response is needed (replaces `void`) |
+| [`Success`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Success.cs) | Indicates a generic successful result |
+| [`Created`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Created.cs) | Indicates a resource was created |
+| [`Updated`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Updated.cs) | Indicates a resource was updated |
+| [`Deleted`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results/Deleted.cs) | Indicates a resource was deleted |
+
+These types are lightweight `readonly struct`s defined in [`Mediary.Core.Results`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/Results).
+
+#### Example: Command with no output
+```csharp
+public class ClearCacheCommand : IRequest<Unit> { }
+
+public class ClearCacheHandler : IRequestHandler<Unit, ClearCacheCommand>
+{
+    public Task<Unit> HandleAsync(ClearCacheCommand request) =>
+        Task.FromResult(Unit.Value);
+}
+```
+
+#### Example: Command with semantic return
+
+```csharp
+public class CreateUserCommand : IRequest<Created> { }
+
+public class CreateUserHandler : IRequestHandler<Created, CreateUserCommand>
+{
+    public Task<Created> HandleAsync(CreateUserCommand request) =>
+        Task.FromResult(Created.Value);
+}
+```
+
+---
+
 ## 🔖 Request Metadata
 
 You can optionally annotate your request types with descriptive metadata using the `[RequestInfo]` attribute:
@@ -190,65 +262,24 @@ This metadata is also accessible from within handlers or behaviors via extension
 
 ---
 
-## ✅ Core Interfaces
-
-```csharp
-public interface IRequest { }
-
-public interface IRequest<TResponse> { }
-
-public interface IRequestHandler<TRequest>
-    where TRequest : IRequest
-{
-    Task HandleAsync(TRequest request);
-}
-
-public interface IRequestHandler<TResponse, TRequest>
-    where TRequest : IRequest<TResponse>
-{
-    Task<TResponse> HandleAsync(TRequest request);
-}
-
-public interface IRequestPipelineBehavior<TRequest>
-    where TRequest : IRequest
-{
-    Task HandleAsync(TRequest request, Func<Task> next);
-}
-
-public interface IRequestPipelineBehavior<TResponse, TRequest>
-    where TRequest : IRequest<TResponse>
-{
-    Task<TResponse> HandleAsync(TRequest request, Func<Task<TResponse>> next);
-}
-
-public interface IRequestDispatcher
-{
-    Task DispatchAsync<TRequest>(TRequest request)
-        where TRequest : IRequest;
-
-    Task<TResponse> ExecuteAsync<TResponse, TRequest>(TRequest request)
-        where TRequest : IRequest<TResponse>;
-}
-```
-
----
-
 ## 🪪 Aliases
 
 For semantic clarity, Mediary exposes aliases for intent-based request types:
 
 | Alias                 | Inherits              | Purpose                           |
 | --------------------- | --------------------- | --------------------------------- |
-| `IQuery`              | `IRequest`            | Read-only request, no response    |
-| `IQuery<TResponse>`   | `IRequest<TResponse>` | Read-only request with a response |
-| `ICommand`            | `IRequest`            | Write command, no response        |
-| `ICommand<TResponse>` | `IRequest<TResponse>` | Write command with a response     |
+| [`IQuery<TResponse>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/IQuery.cs) | [`IRequest<TResponse>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/IRequest.cs) | Read-only request                 |
+| [`ICommand<TResponse>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/ICommand.cs) | [`IRequest<TResponse>`](https://github.com/facus26/Mediary/blob/main/src/Mediary/Core/IRequest.cs) | Write command                     |
 
 Aliases are optional and meant to improve readability:
 
 ```csharp
+// Represents: GET /users/{id}
 public class GetUserByIdQuery : IQuery<UserDto> { }
+
+// Represents: POST /users
 public class CreateUserCommand : ICommand<UserDto> { }
+
 ```
 
 ---

--- a/src/Mediary.Tests/Core/ResultTypesTests.cs
+++ b/src/Mediary.Tests/Core/ResultTypesTests.cs
@@ -1,0 +1,96 @@
+﻿using Mediary.Core.Results;
+using Xunit;
+
+namespace Mediary.Tests.Core;
+
+public class ResultTypesTests
+{
+    [Fact]
+    public void Unit_ShouldBeEqual()
+    {
+        Assert.Equal(Unit.Value, new Unit());
+        Assert.True(Unit.Value == new Unit());
+        Assert.False(Unit.Value != new Unit());
+    }
+
+    [Fact]
+    public void Success_ShouldBeEqual()
+    {
+        Assert.Equal(Success.Value, new Success());
+        Assert.True(Success.Value == new Success());
+        Assert.False(Success.Value != new Success());
+    }
+
+    [Fact]
+    public void Created_ShouldBeEqual()
+    {
+        Assert.Equal(Created.Value, new Created());
+        Assert.True(Created.Value == new Created());
+        Assert.False(Created.Value != new Created());
+    }
+
+    [Fact]
+    public void Updated_ShouldBeEqual()
+    {
+        Assert.Equal(Updated.Value, new Updated());
+        Assert.True(Updated.Value == new Updated());
+        Assert.False(Updated.Value != new Updated());
+    }
+
+    [Fact]
+    public void Deleted_ShouldBeEqual()
+    {
+        Assert.Equal(Deleted.Value, new Deleted());
+        Assert.True(Deleted.Value == new Deleted());
+        Assert.False(Deleted.Value != new Deleted());
+    }
+
+    [Fact]
+    public void Result_StaticAccessors_ShouldReturnSingletons()
+    {
+        Assert.Equal(Unit.Value, Result.Unit);
+        Assert.Equal(Success.Value, Result.Success);
+        Assert.Equal(Created.Value, Result.Created);
+        Assert.Equal(Updated.Value, Result.Updated);
+        Assert.Equal(Deleted.Value, Result.Deleted);
+    }
+
+    [Theory]
+    [InlineData("()", typeof(Unit))]
+    [InlineData("Success", typeof(Success))]
+    [InlineData("Created", typeof(Created))]
+    [InlineData("Updated", typeof(Updated))]
+    [InlineData("Deleted", typeof(Deleted))]
+    public void ToString_ShouldReturnExpectedValue(string expected, Type type)
+    {
+        var value = Activator.CreateInstance(type);
+        Assert.Equal(expected, value!.ToString());
+    }
+
+    [Theory]
+    [InlineData(typeof(Unit))]
+    [InlineData(typeof(Success))]
+    [InlineData(typeof(Created))]
+    [InlineData(typeof(Updated))]
+    [InlineData(typeof(Deleted))]
+    public void Equals_ShouldReturnTrue_WhenComparingSameType(Type type)
+    {
+        var value = Activator.CreateInstance(type);
+        var other = Activator.CreateInstance(type);
+
+        Assert.True(value!.Equals(other));
+        Assert.True(value.Equals((object)other!));
+    }
+
+    [Theory]
+    [InlineData(typeof(Unit))]
+    [InlineData(typeof(Success))]
+    [InlineData(typeof(Created))]
+    [InlineData(typeof(Updated))]
+    [InlineData(typeof(Deleted))]
+    public void GetHashCode_ShouldReturnZero(Type type)
+    {
+        var value = Activator.CreateInstance(type);
+        Assert.Equal(0, value!.GetHashCode());
+    }
+}

--- a/src/Mediary.Tests/Dispatcher/RequestDispatcherTests.cs
+++ b/src/Mediary.Tests/Dispatcher/RequestDispatcherTests.cs
@@ -10,33 +10,12 @@ namespace Mediary.Tests.Dispatcher;
 public class RequestDispatcherTests
 {
     [Fact]
-    public async Task DispatchAsync_CallsHandlerWithoutBehaviors()
+    public async Task DispatchAsync_CallsHandler()
     {
         // Arrange
         var request = new SampleRequest();
-        var handlerMock = new Mock<IRequestHandler<SampleRequest>>();
-        handlerMock.Setup(h => h.HandleAsync(request)).Returns(Task.CompletedTask);
-
-        var serviceProvider = new ServiceCollection()
-            .AddSingleton(handlerMock.Object)
-            .BuildServiceProvider();
-
-        var dispatcher = new RequestDispatcher(serviceProvider);
-
-        // Act
-        await dispatcher.DispatchAsync(request);
-
-        // Assert
-        handlerMock.Verify(h => h.HandleAsync(request), Times.Once);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_CallsHandlerWithResponse()
-    {
-        // Arrange
-        var request = new SampleRequestWithResponse();
         var expectedResponse = new SampleResponse();
-        var handlerMock = new Mock<IRequestHandler<SampleResponse, SampleRequestWithResponse>>();
+        var handlerMock = new Mock<IRequestHandler<SampleResponse, SampleRequest>>();
         handlerMock.Setup(h => h.HandleAsync(request)).ReturnsAsync(expectedResponse);
 
         var serviceProvider = new ServiceCollection()
@@ -46,7 +25,7 @@ public class RequestDispatcherTests
         var dispatcher = new RequestDispatcher(serviceProvider);
 
         // Act
-        var response = await dispatcher.ExecuteAsync<SampleResponse, SampleRequestWithResponse>(request);
+        var response = await dispatcher.DispatchAsync<SampleResponse, SampleRequest>(request);
 
         // Assert
         Assert.Equal(expectedResponse, response);
@@ -63,23 +42,7 @@ public class RequestDispatcherTests
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            dispatcher.DispatchAsync(request));
-
-        Assert.Contains("No service for", ex.Message);
-        Assert.Contains(request.GetType().Name, ex.Message);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_ThrowsIfHandlerNotRegistered()
-    {
-        // Arrange
-        var request = new SampleRequestWithResponse();
-        var serviceProvider = new ServiceCollection().BuildServiceProvider();
-        var dispatcher = new RequestDispatcher(serviceProvider);
-
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            dispatcher.ExecuteAsync<SampleResponse, SampleRequestWithResponse>(request));
+            dispatcher.DispatchAsync<SampleResponse, SampleRequest>(request));
 
         Assert.Contains("No service for", ex.Message);
         Assert.Contains(request.GetType().Name, ex.Message);

--- a/src/Mediary.Tests/Dispatcher/Utils/RequestInfoTests.cs
+++ b/src/Mediary.Tests/Dispatcher/Utils/RequestInfoTests.cs
@@ -18,51 +18,7 @@ public class RequestInfoTests
 
         // Assert
         Assert.Equal("Sample request", description);
-        Assert.Equal(new[] { "sample" }, tags);
-    }
-
-    [Fact]
-    public void GetInfo_ShouldReturnAttributeInstance_WhenPresent()
-    {
-        // Arrange
-        var request = new SampleRequest();
-
-        // Act
-        var info = request.GetInfo();
-
-        // Assert
-        Assert.NotNull(info);
-        Assert.Equal("Sample request", info!.Description);
-        Assert.Contains("sample", info.Tags);
-    }
-    [Fact]
-    public void GetDescription_ShouldReturnDescription_WhenAttributeIsPresent_InRequestWithResponse()
-    {
-        // Arrange
-        var request = new SampleRequestWithResponse();
-
-        // Act
-        var description = request.GetDescription();
-        var tags = request.GetTags();
-
-        // Assert
-        Assert.Equal("Sample request with response", description);
-        Assert.Equal(new[] { "sample" }, tags);
-    }
-
-    [Fact]
-    public void GetInfo_ShouldReturnAttributeInstance_WhenPresent_InRequestWithResponse()
-    {
-        // Arrange
-        var request = new SampleRequestWithResponse();
-
-        // Act
-        var info = request.GetInfo();
-
-        // Assert
-        Assert.NotNull(info);
-        Assert.Equal("Sample request with response", info!.Description);
-        Assert.Contains("sample", info.Tags);
+        Assert.Equal(["sample"], tags);
     }
 
     [Fact]
@@ -84,7 +40,7 @@ public class RequestInfoTests
     public void GetDescription_ShouldReturnDescription_WhenOnlyDescriptionIsPresent()
     {
         // Arrange
-        var request = new SampleRequestOnlyWithDescription();
+        var request = new SampleRequestWithoutTags();
 
         // Act
         var description = request.GetDescription();

--- a/src/Mediary.Tests/Dispatcher/Utils/RequestInfoTests.cs
+++ b/src/Mediary.Tests/Dispatcher/Utils/RequestInfoTests.cs
@@ -11,14 +11,20 @@ public class RequestInfoTests
     {
         // Arrange
         var request = new SampleRequest();
+        var expectedDescription = "Sample request";
+        var expectedTags = new[] { "sample" };
 
         // Act
+        var info = request.GetInfo();
         var description = request.GetDescription();
         var tags = request.GetTags();
 
         // Assert
-        Assert.Equal("Sample request", description);
-        Assert.Equal(["sample"], tags);
+        Assert.NotNull(info);
+        Assert.Equal(expectedDescription, info.Description);
+        Assert.Equal(expectedDescription, description);
+        Assert.Equal(expectedTags, info.Tags);
+        Assert.Equal(expectedTags, tags);
     }
 
     [Fact]
@@ -28,10 +34,12 @@ public class RequestInfoTests
         var request = new SampleRequestWithoutInfo();
 
         // Act
+        var info = request.GetInfo();
         var description = request.GetDescription();
         var tags = request.GetTags();
 
         // Assert
+        Assert.Null(info);
         Assert.Null(description);
         Assert.Empty(tags);
     }
@@ -41,13 +49,17 @@ public class RequestInfoTests
     {
         // Arrange
         var request = new SampleRequestWithoutTags();
+        var expectedDescription = "Sample request";
 
         // Act
+        var info = request.GetInfo();
         var description = request.GetDescription();
         var tags = request.GetTags();
 
         // Assert
-        Assert.Equal("Sample request", description);
+        Assert.NotNull(info);
+        Assert.Equal(expectedDescription, info.Description);
+        Assert.Equal(expectedDescription, description);
         Assert.Empty(tags);
     }
 }

--- a/src/Mediary.Tests/Helpers/Samples.cs
+++ b/src/Mediary.Tests/Helpers/Samples.cs
@@ -4,39 +4,21 @@ using Mediary.Pipeline;
 
 namespace Mediary.Tests.Helpers;
 
-[RequestInfo("Sample request")]
-public class SampleRequestOnlyWithDescription : IRequest { }
-public class SampleRequestWithoutInfo : IRequest { }
-public class SampleRequestWithResponseWithoutInfo : IRequest<SampleResponse> { }
-public class SampleClosedRequest : IRequest { }
+public class SampleResponse { }
+public class SampleClosedRequest : IRequest<SampleResponse> { }
 
 [RequestInfo("Sample request", "sample")]
-public class SampleRequest : IRequest { }
+public class SampleRequest : IRequest<SampleResponse> { }
 
-[RequestInfo("Sample request with response", "sample")]
-public class SampleRequestWithResponse : IRequest<SampleResponse> { }
+[RequestInfo("Sample request")]
+public class SampleRequestWithoutTags : IRequest<SampleResponse> { }
+public class SampleRequestWithoutInfo : IRequest<SampleResponse> { }
 
-public class SampleResponse { }
 
-public class SampleRequestHandler : IRequestHandler<SampleRequest>
+public class SampleRequestHandler : IRequestHandler<SampleResponse, SampleRequest>
 {
-    public Task HandleAsync(SampleRequest request) => Task.CompletedTask;
-}
-
-public class SampleRequestWithResponseHandler : IRequestHandler<SampleResponse, SampleRequestWithResponse>
-{
-    public Task<SampleResponse> HandleAsync(SampleRequestWithResponse request) =>
+    public Task<SampleResponse> HandleAsync(SampleRequest request) =>
         Task.FromResult(new SampleResponse());
-}
-
-public class SampleLoggingBehavior : IRequestPipelineBehavior<SampleRequest>
-{
-    public Task HandleAsync(SampleRequest request, Func<Task> next) => next();
-}
-
-public class SampleLoggingBehaviorWithResponse : IRequestPipelineBehavior<SampleResponse, SampleRequestWithResponse>
-{
-    public Task<SampleResponse> HandleAsync(SampleRequestWithResponse request, Func<Task<SampleResponse>> next) => next();
 }
 
 public class SampleOpenLoggingBehavior<TResponse, TRequest> : IRequestPipelineBehavior<TResponse, TRequest>
@@ -45,7 +27,12 @@ public class SampleOpenLoggingBehavior<TResponse, TRequest> : IRequestPipelineBe
     public Task<TResponse> HandleAsync(TRequest request, Func<Task<TResponse>> next) => next();
 }
 
-public class ClosedLoggingBehavior : IRequestPipelineBehavior<SampleClosedRequest>
+public class SampleLoggingBehavior : IRequestPipelineBehavior<SampleResponse, SampleRequest>
 {
-    public Task HandleAsync(SampleClosedRequest request, Func<Task> next) => next();
+    public Task<SampleResponse> HandleAsync(SampleRequest request, Func<Task<SampleResponse>> next) => next();
+}
+
+public class ClosedLoggingBehavior : IRequestPipelineBehavior<SampleResponse, SampleClosedRequest>
+{
+    public Task<SampleResponse> HandleAsync(SampleClosedRequest request, Func<Task<SampleResponse>> next) => next();
 }

--- a/src/Mediary.Tests/MediaryBuilderTests.cs
+++ b/src/Mediary.Tests/MediaryBuilderTests.cs
@@ -15,11 +15,11 @@ public class MediaryBuilderTests
         var services = new ServiceCollection();
         var builder = new MediaryBuilder(services);
 
-        builder.AddRequestHandler<SampleRequest, SampleRequestHandler>();
+        builder.AddRequestHandler<SampleResponse, SampleRequest, SampleRequestHandler>();
 
         // Act
         var provider = services.BuildServiceProvider();
-        var handler = provider.GetService<IRequestHandler<SampleRequest>>();
+        var handler = provider.GetService<IRequestHandler<SampleResponse, SampleRequest>>();
 
         // Assert
         Assert.NotNull(handler);
@@ -27,57 +27,21 @@ public class MediaryBuilderTests
     }
 
     [Fact]
-    public void AddRequestHandler_WithResponse_Registers_Handler_Correctly()
+    public void AddPipelineBehavior_Registers_Correctly()
     {
         // Arrange
         var services = new ServiceCollection();
         var builder = new MediaryBuilder(services);
 
-        builder.AddRequestHandler<SampleResponse, SampleRequestWithResponse, SampleRequestWithResponseHandler>();
+        builder.AddPipelineBehaviors<SampleResponse, SampleRequest, SampleLoggingBehavior>();
 
         // Act
         var provider = services.BuildServiceProvider();
-        var handler = provider.GetService<IRequestHandler<SampleResponse, SampleRequestWithResponse>>();
-
-        // Assert
-        Assert.NotNull(handler);
-        Assert.IsType<SampleRequestWithResponseHandler>(handler);
-    }
-
-    [Fact]
-    public void AddPipelineBehavior_Registers_NonGeneric_Correctly()
-    {
-        // Arrange
-        var services = new ServiceCollection();
-        var builder = new MediaryBuilder(services);
-
-        builder.AddPipelineBehaviors<SampleRequest, SampleLoggingBehavior>();
-
-        // Act
-        var provider = services.BuildServiceProvider();
-        var behavior = provider.GetService<IRequestPipelineBehavior<SampleRequest>>();
+        var behavior = provider.GetService<IRequestPipelineBehavior<SampleResponse, SampleRequest>>();
 
         // Assert
         Assert.NotNull(behavior);
         Assert.IsType<SampleLoggingBehavior>(behavior);
-    }
-
-    [Fact]
-    public void AddPipelineBehavior_WithResponse_Registers_Correctly()
-    {
-        // Arrange
-        var services = new ServiceCollection();
-        var builder = new MediaryBuilder(services);
-
-        builder.AddPipelineBehaviors<SampleResponse, SampleRequestWithResponse, SampleLoggingBehaviorWithResponse>();
-
-        // Act
-        var provider = services.BuildServiceProvider();
-        var behavior = provider.GetService<IRequestPipelineBehavior<SampleResponse, SampleRequestWithResponse>>();
-
-        // Assert
-        Assert.NotNull(behavior);
-        Assert.IsType<SampleLoggingBehaviorWithResponse>(behavior);
     }
 
     [Fact]
@@ -91,11 +55,11 @@ public class MediaryBuilderTests
 
         // Act
         var provider = services.BuildServiceProvider();
-        var behavior = provider.GetService<IRequestPipelineBehavior<SampleResponse, SampleRequestWithResponse>>();
+        var behavior = provider.GetService<IRequestPipelineBehavior<SampleResponse, SampleRequest>>();
 
         // Assert
         Assert.NotNull(behavior);
-        Assert.IsType<SampleOpenLoggingBehavior<SampleResponse, SampleRequestWithResponse>>(behavior);
+        Assert.IsType<SampleOpenLoggingBehavior<SampleResponse, SampleRequest>>(behavior);
     }
 
     [Fact]
@@ -137,7 +101,7 @@ public class MediaryBuilderTests
 
         // Act
         var provider = services.BuildServiceProvider();
-        var handler = provider.GetService<IRequestHandler<SampleRequest>>();
+        var handler = provider.GetService<IRequestHandler<SampleResponse, SampleRequest>>();
 
         // Assert
         Assert.NotNull(handler);
@@ -155,7 +119,7 @@ public class MediaryBuilderTests
 
         // Act
         var provider = services.BuildServiceProvider();
-        var behavior = provider.GetService<IRequestPipelineBehavior<SampleRequest>>();
+        var behavior = provider.GetService<IRequestPipelineBehavior<SampleResponse, SampleRequest>>();
 
         // Assert
         Assert.NotNull(behavior);

--- a/src/Mediary.Tests/MediaryServiceCollectionExtensionsTests.cs
+++ b/src/Mediary.Tests/MediaryServiceCollectionExtensionsTests.cs
@@ -49,10 +49,7 @@ public class MediaryServiceCollectionExtensionsTests
 
     private sealed class FakeDispatcher : IRequestDispatcher
     {
-        public Task DispatchAsync<TRequest>(TRequest request) where TRequest : IRequest =>
-            Task.CompletedTask;
-
-        public Task<TResponse> ExecuteAsync<TResponse, TRequest>(TRequest request)
+        public Task<TResponse> DispatchAsync<TResponse, TRequest>(TRequest request)
             where TRequest : IRequest<TResponse> =>
             Task.FromResult(default(TResponse)!);
     }

--- a/src/Mediary.Tests/Pipeline/Behaviors/LoggingBehaviorTests.cs
+++ b/src/Mediary.Tests/Pipeline/Behaviors/LoggingBehaviorTests.cs
@@ -13,10 +13,10 @@ public class LoggingBehaviorTests
     public async Task HandleAsync_LogsBeforeAndAfterHandling_RequestWithInfo()
     {
         // Arrange
-        var loggerMock = new Mock<ILogger<LoggingBehavior<SampleResponse, SampleRequestWithResponse>>>();
-        var behavior = new LoggingBehavior<SampleResponse, SampleRequestWithResponse>(loggerMock.Object);
+        var loggerMock = new Mock<ILogger<LoggingBehavior<SampleResponse, SampleRequest>>>();
+        var behavior = new LoggingBehavior<SampleResponse, SampleRequest>(loggerMock.Object);
 
-        var request = new SampleRequestWithResponse();
+        var request = new SampleRequest();
         var response = new SampleResponse();
 
         var expectedMessage = $"Handling {request.GetType().Name} - {request.GetDescription()!}";
@@ -47,10 +47,10 @@ public class LoggingBehaviorTests
     public async Task HandleAsync_LogsBeforeAndAfterHandling_RequestWithoutInfo()
     {
         // Arrange
-        var loggerMock = new Mock<ILogger<LoggingBehavior<SampleResponse, SampleRequestWithResponseWithoutInfo>>>();
-        var behavior = new LoggingBehavior<SampleResponse, SampleRequestWithResponseWithoutInfo>(loggerMock.Object);
+        var loggerMock = new Mock<ILogger<LoggingBehavior<SampleResponse, SampleRequestWithoutInfo>>>();
+        var behavior = new LoggingBehavior<SampleResponse, SampleRequestWithoutInfo>(loggerMock.Object);
 
-        var request = new SampleRequestWithResponseWithoutInfo();
+        var request = new SampleRequestWithoutInfo();
         var response = new SampleResponse();
 
         var expectedMessage = $"Handling {request.GetType().Name}";
@@ -80,10 +80,10 @@ public class LoggingBehaviorTests
     [Fact]
     public async Task HandleAsync_LogsErrorOnException()
     {
-        var loggerMock = new Mock<ILogger<LoggingBehavior<SampleResponse, SampleRequestWithResponse>>>();
-        var behavior = new LoggingBehavior<SampleResponse, SampleRequestWithResponse>(loggerMock.Object);
+        var loggerMock = new Mock<ILogger<LoggingBehavior<SampleResponse, SampleRequest>>>();
+        var behavior = new LoggingBehavior<SampleResponse, SampleRequest>(loggerMock.Object);
 
-        var request = new SampleRequestWithResponse();
+        var request = new SampleRequest();
         var exception = new InvalidOperationException("Test failure");
 
         // Act & Assert

--- a/src/Mediary.Tests/Pipeline/Behaviors/PerformanceBehaviorTests.cs
+++ b/src/Mediary.Tests/Pipeline/Behaviors/PerformanceBehaviorTests.cs
@@ -13,10 +13,10 @@ public class PerformanceBehaviorTests
     public async Task HandleAsync_LogsExecutionTime_RequestWithInfo()
     {
         // Arrange
-        var loggerMock = new Mock<ILogger<PerformanceBehavior<SampleResponse, SampleRequestWithResponse>>>();
-        var behavior = new PerformanceBehavior<SampleResponse, SampleRequestWithResponse>(loggerMock.Object);
+        var loggerMock = new Mock<ILogger<PerformanceBehavior<SampleResponse, SampleRequest>>>();
+        var behavior = new PerformanceBehavior<SampleResponse, SampleRequest>(loggerMock.Object);
 
-        var request = new SampleRequestWithResponse();
+        var request = new SampleRequest();
         var response = new SampleResponse();
 
         var expectedMessage = $"Handling {request.GetType().Name} - {request.GetDescription()!}";
@@ -49,10 +49,10 @@ public class PerformanceBehaviorTests
     public async Task HandleAsync_LogsExecutionTime_RequestWithoutInfo()
     {
         // Arrange
-        var loggerMock = new Mock<ILogger<PerformanceBehavior<SampleResponse, SampleRequestWithResponseWithoutInfo>>>();
-        var behavior = new PerformanceBehavior<SampleResponse, SampleRequestWithResponseWithoutInfo>(loggerMock.Object);
+        var loggerMock = new Mock<ILogger<PerformanceBehavior<SampleResponse, SampleRequestWithoutInfo>>>();
+        var behavior = new PerformanceBehavior<SampleResponse, SampleRequestWithoutInfo>(loggerMock.Object);
 
-        var request = new SampleRequestWithResponseWithoutInfo();
+        var request = new SampleRequestWithoutInfo();
         var response = new SampleResponse();
 
         var expectedMessage = $"Handling {request.GetType().Name}";
@@ -84,10 +84,10 @@ public class PerformanceBehaviorTests
     [Fact]
     public async Task HandleAsync_LogsErrorOnException()
     {
-        var loggerMock = new Mock<ILogger<PerformanceBehavior<SampleResponse, SampleRequestWithResponse>>>();
-        var behavior = new PerformanceBehavior<SampleResponse, SampleRequestWithResponse>(loggerMock.Object);
+        var loggerMock = new Mock<ILogger<PerformanceBehavior<SampleResponse, SampleRequest>>>();
+        var behavior = new PerformanceBehavior<SampleResponse, SampleRequest>(loggerMock.Object);
 
-        var request = new SampleRequestWithResponse();
+        var request = new SampleRequest();
         var exception = new InvalidOperationException("Test failure");
 
         // Act & Assert

--- a/src/Mediary/Core/Extensions/RequestExtensions.cs
+++ b/src/Mediary/Core/Extensions/RequestExtensions.cs
@@ -28,26 +28,5 @@ public static class RequestExtensions
     public static RequestInfoAttribute? GetInfo<TResponse>(
         this IRequest<TResponse> request
     ) => RequestInfo.Get(request.GetType());
-
-    /// <summary>
-    /// Gets the description of a non-generic request from the <see cref="RequestInfoAttribute"/>, if available.
-    /// </summary>
-    public static string? GetDescription(
-        this IRequest request
-    ) => RequestInfo.GetDescription(request.GetType());
-
-    /// <summary>
-    /// Gets the tags of a non-generic request from the <see cref="RequestInfoAttribute"/>, if available.
-    /// </summary>
-    public static string[] GetTags(
-        this IRequest request
-    ) => RequestInfo.GetTags(request.GetType());
-
-    /// <summary>
-    /// Gets the <see cref="RequestInfoAttribute"/> instance from a non-generic request, if applied.
-    /// </summary>
-    public static RequestInfoAttribute? GetInfo(
-        this IRequest request
-    ) => RequestInfo.Get(request.GetType());
 }
 

--- a/src/Mediary/Core/ICommand.cs
+++ b/src/Mediary/Core/ICommand.cs
@@ -1,12 +1,6 @@
 ﻿namespace Mediary.Core;
 
 /// <summary>
-/// Represents a write command that does not return a value.
-/// Typically used to change system state (create, update, delete).
-/// </summary>
-public interface ICommand : IRequest { }
-
-/// <summary>
 /// Represents a write command that returns a response of type <typeparamref name="TResponse"/>.
 /// Typically used to change system state and return a result.
 /// </summary>

--- a/src/Mediary/Core/IQuery.cs
+++ b/src/Mediary/Core/IQuery.cs
@@ -1,12 +1,6 @@
 ﻿namespace Mediary.Core;
 
 /// <summary>
-/// Represents a read-only query that does not return a value.
-/// Rarely used; prefer <see cref="IQuery{TResponse}"/> for queries that return data.
-/// </summary>
-public interface IQuery : IRequest { }
-
-/// <summary>
 /// Represents a read-only query that returns a response of type <typeparamref name="TResponse"/>.
 /// Typically used to retrieve data without causing side effects.
 /// </summary>

--- a/src/Mediary/Core/IRequest.cs
+++ b/src/Mediary/Core/IRequest.cs
@@ -1,12 +1,6 @@
 ﻿namespace Mediary.Core;
 
 /// <summary>
-/// Represents a request that does not return a response.
-/// Base interface for commands or fire-and-forget actions.
-/// </summary>
-public interface IRequest { }
-
-/// <summary>
 /// Represents a request that returns a response of type <typeparamref name="TResponse"/>.
 /// Base interface for queries and commands with results.
 /// </summary>

--- a/src/Mediary/Core/IRequestHandler.cs
+++ b/src/Mediary/Core/IRequestHandler.cs
@@ -15,18 +15,3 @@ public interface IRequestHandler<TResponse, TRequest>
     /// <returns>A task representing the asynchronous operation, with a response of type <typeparamref name="TResponse"/>.</returns>
     public Task<TResponse> HandleAsync(TRequest request);
 }
-
-/// <summary>
-/// Defines a handler for a request that does not return a response.
-/// </summary>
-/// <typeparam name="TRequest">The request type handled.</typeparam>
-public interface IRequestHandler<TRequest>
-    where TRequest : IRequest
-{
-    /// <summary>
-    /// Handles the specified request.
-    /// </summary>
-    /// <param name="request">The request to handle.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    public Task HandleAsync(TRequest request);
-}

--- a/src/Mediary/Core/Results/Created.cs
+++ b/src/Mediary/Core/Results/Created.cs
@@ -1,0 +1,15 @@
+﻿namespace Mediary.Core.Results;
+
+public readonly struct Created : IEquatable<Created>
+{
+    public static readonly Created Value = new();
+
+    public override string ToString() => "Created";
+    public override bool Equals(object? obj) => obj is Created;
+    public bool Equals(Created other) => true;
+    public override int GetHashCode() => 0;
+
+    public static bool operator ==(Created left, Created right) => true;
+    public static bool operator !=(Created left, Created right) => false;
+}
+

--- a/src/Mediary/Core/Results/Created.cs
+++ b/src/Mediary/Core/Results/Created.cs
@@ -1,5 +1,8 @@
 ﻿namespace Mediary.Core.Results;
 
+/// <summary>
+/// Indicates that a resource was successfully created. Used as a semantic response for commands.
+/// </summary>
 public readonly struct Created : IEquatable<Created>
 {
     public static readonly Created Value = new();

--- a/src/Mediary/Core/Results/Deleted.cs
+++ b/src/Mediary/Core/Results/Deleted.cs
@@ -1,5 +1,8 @@
 ﻿namespace Mediary.Core.Results;
 
+/// <summary>
+/// Indicates that a resource was successfully deleted. Used as a semantic response for commands.
+/// </summary>
 public readonly struct Deleted : IEquatable<Deleted>
 {
     public static readonly Deleted Value = new();

--- a/src/Mediary/Core/Results/Deleted.cs
+++ b/src/Mediary/Core/Results/Deleted.cs
@@ -1,0 +1,15 @@
+﻿namespace Mediary.Core.Results;
+
+public readonly struct Deleted : IEquatable<Deleted>
+{
+    public static readonly Deleted Value = new();
+
+    public override string ToString() => "Deleted";
+    public override bool Equals(object? obj) => obj is Deleted;
+    public bool Equals(Deleted other) => true;
+    public override int GetHashCode() => 0;
+
+    public static bool operator ==(Deleted left, Deleted right) => true;
+    public static bool operator !=(Deleted left, Deleted right) => false;
+}
+

--- a/src/Mediary/Core/Results/Result.cs
+++ b/src/Mediary/Core/Results/Result.cs
@@ -1,0 +1,10 @@
+﻿namespace Mediary.Core.Results;
+
+public static class Result
+{
+    public static Unit Unit => Unit.Value;
+    public static Success Success => Success.Value;
+    public static Created Created => Created.Value;
+    public static Updated Updated => Updated.Value;
+    public static Deleted Deleted => Deleted.Value;
+}

--- a/src/Mediary/Core/Results/Result.cs
+++ b/src/Mediary/Core/Results/Result.cs
@@ -1,5 +1,8 @@
 ﻿namespace Mediary.Core.Results;
 
+/// <summary>
+/// Provides static access to semantic result types such as <see cref="Unit"/>, <see cref="Success"/>, <see cref="Created"/>, etc.
+/// </summary>
 public static class Result
 {
     public static Unit Unit => Unit.Value;

--- a/src/Mediary/Core/Results/Success.cs
+++ b/src/Mediary/Core/Results/Success.cs
@@ -1,5 +1,8 @@
 ﻿namespace Mediary.Core.Results;
 
+/// <summary>
+/// Represents a generic successful result for a command that does not return data.
+/// </summary>
 public readonly struct Success : IEquatable<Success>
 {
     public static readonly Success Value = new();

--- a/src/Mediary/Core/Results/Success.cs
+++ b/src/Mediary/Core/Results/Success.cs
@@ -1,0 +1,15 @@
+﻿namespace Mediary.Core.Results;
+
+public readonly struct Success : IEquatable<Success>
+{
+    public static readonly Success Value = new();
+
+    public override string ToString() => "Success";
+    public override bool Equals(object? obj) => obj is Success;
+    public bool Equals(Success other) => true;
+    public override int GetHashCode() => 0;
+
+    public static bool operator ==(Success left, Success right) => true;
+    public static bool operator !=(Success left, Success right) => false;
+}
+

--- a/src/Mediary/Core/Results/Unit.cs
+++ b/src/Mediary/Core/Results/Unit.cs
@@ -1,0 +1,15 @@
+﻿namespace Mediary.Core.Results;
+
+public readonly struct Unit : IEquatable<Unit>
+{
+    public static readonly Unit Value = new();
+
+    public override string ToString() => "()";
+    public override bool Equals(object? obj) => obj is Unit;
+    public bool Equals(Unit other) => true;
+    public override int GetHashCode() => 0;
+
+    public static bool operator ==(Unit left, Unit right) => true;
+    public static bool operator !=(Unit left, Unit right) => false;
+}
+

--- a/src/Mediary/Core/Results/Unit.cs
+++ b/src/Mediary/Core/Results/Unit.cs
@@ -1,5 +1,8 @@
 ﻿namespace Mediary.Core.Results;
 
+/// <summary>
+/// Represents the absence of a meaningful value. Equivalent to <c>void</c> but usable as a return type.
+/// </summary>
 public readonly struct Unit : IEquatable<Unit>
 {
     public static readonly Unit Value = new();

--- a/src/Mediary/Core/Results/Updated.cs
+++ b/src/Mediary/Core/Results/Updated.cs
@@ -1,5 +1,8 @@
 ﻿namespace Mediary.Core.Results;
 
+/// <summary>
+/// Indicates that a resource was successfully updated. Used as a semantic response for commands.
+/// </summary>
 public readonly struct Updated : IEquatable<Updated>
 {
     public static readonly Updated Value = new();

--- a/src/Mediary/Core/Results/Updated.cs
+++ b/src/Mediary/Core/Results/Updated.cs
@@ -1,0 +1,15 @@
+﻿namespace Mediary.Core.Results;
+
+public readonly struct Updated : IEquatable<Updated>
+{
+    public static readonly Updated Value = new();
+
+    public override string ToString() => "Updated";
+    public override bool Equals(object? obj) => obj is Updated;
+    public bool Equals(Updated other) => true;
+    public override int GetHashCode() => 0;
+
+    public static bool operator ==(Updated left, Updated right) => true;
+    public static bool operator !=(Updated left, Updated right) => false;
+}
+

--- a/src/Mediary/Dispatcher/IRequestDispatcher.cs
+++ b/src/Mediary/Dispatcher/IRequestDispatcher.cs
@@ -8,21 +8,12 @@ namespace Mediary.Dispatcher;
 public interface IRequestDispatcher
 {
     /// <summary>
-    /// Dispatches a request that does not return a response.
-    /// </summary>
-    /// <typeparam name="TRequest">The type of request.</typeparam>
-    /// <param name="request">The request instance.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    public Task DispatchAsync<TRequest>(TRequest request)
-        where TRequest : IRequest;
-
-    /// <summary>
     /// Executes a request and returns a response.
     /// </summary>
     /// <typeparam name="TResponse">The response type.</typeparam>
     /// <typeparam name="TRequest">The request type.</typeparam>
     /// <param name="request">The request to execute.</param>
     /// <returns>A task containing the response.</returns>
-    public Task<TResponse> ExecuteAsync<TResponse, TRequest>(TRequest request)
+    public Task<TResponse> DispatchAsync<TResponse, TRequest>(TRequest request)
         where TRequest : IRequest<TResponse>;
 }

--- a/src/Mediary/Dispatcher/RequestDispatcher.cs
+++ b/src/Mediary/Dispatcher/RequestDispatcher.cs
@@ -20,17 +20,7 @@ public sealed class RequestDispatcher : IRequestDispatcher
         _serviceProvider = serviceProvider;
 
     /// <inheritdoc />
-    public async Task DispatchAsync<TRequest>(TRequest request)
-        where TRequest : IRequest
-    {
-        var handler = _serviceProvider.GetRequiredService<IRequestHandler<TRequest>>();
-        var behaviors = _serviceProvider.GetServices<IRequestPipelineBehavior<TRequest>>().ToList();
-
-        await BehaviorInvoker.ExecuteWithPipeline(request, handler, behaviors);
-    }
-
-    /// <inheritdoc />
-    public async Task<TResponse> ExecuteAsync<TResponse, TRequest>(TRequest request)
+    public async Task<TResponse> DispatchAsync<TResponse, TRequest>(TRequest request)
         where TRequest : IRequest<TResponse>
     {
         var handler = _serviceProvider.GetRequiredService<IRequestHandler<TResponse, TRequest>>();

--- a/src/Mediary/Mediary.csproj
+++ b/src/Mediary/Mediary.csproj
@@ -6,15 +6,15 @@
     <Nullable>enable</Nullable>
 
     <!-- Versioning -->
-    <Version>0.2.0</Version>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <FileVersion>0.2.0.0</FileVersion>
-    <PackageVersion>0.2.0</PackageVersion>
+    <Version>0.3.0</Version>
+    <AssemblyVersion>0.3.0.0</AssemblyVersion>
+    <FileVersion>0.3.0.0</FileVersion>
+    <PackageVersion>0.3.0</PackageVersion>
 
     <!-- NuGet Package Metadata -->
     <PackageId>Mediary</PackageId>
     <Title>Mediary</Title>
-    <Description>Mediary is a lightweight .NET request/response dispatcher with pipeline support — inspired by MediatR but built from scratch with no external dependencies.</Description>
+    <Description>Mediary is a minimal, open-source library for .NET that implements the Request/Handler (Mediator) pattern with pipeline support — built from scratch with no external dependencies.</Description>
     <Authors>Facundo Juarez</Authors>
     <Company>facus26</Company>
     <PackageProjectUrl>https://github.com/facus26/Mediary</PackageProjectUrl>

--- a/src/Mediary/MediaryBuilder.cs
+++ b/src/Mediary/MediaryBuilder.cs
@@ -26,20 +26,6 @@ public sealed class MediaryBuilder
     }
 
     /// <summary>
-    /// Registers a single non-generic request handler for a specific request type.
-    /// </summary>
-    /// <typeparam name="TRequest">The request type.</typeparam>
-    /// <typeparam name="TImplementation">The concrete implementation of the handler.</typeparam>
-    /// <returns>The current instance of <see cref="MediaryBuilder"/>.</returns>
-    public MediaryBuilder AddRequestHandler<TRequest, TImplementation>()
-        where TRequest : IRequest
-        where TImplementation : class, IRequestHandler<TRequest>
-    {
-        Services.AddScoped<IRequestHandler<TRequest>, TImplementation>();
-        return this;
-    }
-
-    /// <summary>
     /// Registers a request handler with a response for a specific request type.
     /// </summary>
     /// <typeparam name="TResponse">The response type.</typeparam>
@@ -51,20 +37,6 @@ public sealed class MediaryBuilder
         where TImplementation : class, IRequestHandler<TResponse, TRequest>
     {
         Services.AddScoped<IRequestHandler<TResponse, TRequest>, TImplementation>();
-        return this;
-    }
-
-    /// <summary>
-    /// Registers a pipeline behavior for a non-generic request type.
-    /// </summary>
-    /// <typeparam name="TRequest">The request type.</typeparam>
-    /// <typeparam name="TImplementation">The concrete implementation of the behavior.</typeparam>
-    /// <returns>The current instance of <see cref="MediaryBuilder"/>.</returns>
-    public MediaryBuilder AddPipelineBehaviors<TRequest, TImplementation>()
-        where TImplementation : class, IRequestPipelineBehavior<TRequest>
-        where TRequest : IRequest
-    {
-        Services.AddScoped<IRequestPipelineBehavior<TRequest>, TImplementation>();
         return this;
     }
 
@@ -94,9 +66,7 @@ public sealed class MediaryBuilder
     {
         var interfaces = implementationType.GetInterfaces()
             .Where(iface => iface.IsGenericType)
-            .Where(iface =>
-                iface.GetGenericTypeDefinition() == typeof(IRequestPipelineBehavior<>) ||
-                iface.GetGenericTypeDefinition() == typeof(IRequestPipelineBehavior<,>))
+            .Where(iface => iface.GetGenericTypeDefinition() == typeof(IRequestPipelineBehavior<,>))
             .Where(iface => iface.ContainsGenericParameters)
             .Distinct()
             .ToList();
@@ -121,9 +91,8 @@ public sealed class MediaryBuilder
             .GetTypes()
             .Where(t => !t.IsAbstract && !t.IsInterface && t.IsClass)
             .SelectMany(t => t.GetInterfaces(), (impl, iface) => new { impl, iface })
-            .Where(x => x.iface.IsGenericType &&
-                        (x.iface.GetGenericTypeDefinition() == typeof(IRequestHandler<>) ||
-                         x.iface.GetGenericTypeDefinition() == typeof(IRequestHandler<,>)))
+            .Where(x => x.iface.IsGenericType)
+            .Where(x => x.iface.GetGenericTypeDefinition() == typeof(IRequestHandler<,>))
             .ToList();
 
         foreach (var reg in handlerTypes)
@@ -145,9 +114,8 @@ public sealed class MediaryBuilder
             .GetTypes()
             .Where(t => !t.IsAbstract && !t.IsInterface && t.IsClass)
             .SelectMany(t => t.GetInterfaces(), (impl, iface) => new { impl, iface })
-            .Where(x => x.iface.IsGenericType &&
-                (x.iface.GetGenericTypeDefinition() == typeof(IRequestPipelineBehavior<>) ||
-                 x.iface.GetGenericTypeDefinition() == typeof(IRequestPipelineBehavior<,>)))
+            .Where(x => x.iface.IsGenericType)
+            .Where(x => x.iface.GetGenericTypeDefinition() == typeof(IRequestPipelineBehavior<,>))
             .ToList();
 
         foreach (var reg in types)

--- a/src/Mediary/Pipeline/BehaviorInvoker.cs
+++ b/src/Mediary/Pipeline/BehaviorInvoker.cs
@@ -9,32 +9,6 @@ namespace Mediary.Pipeline;
 public static class BehaviorInvoker
 {
     /// <summary>
-    /// Executes a request without response, invoking the pipeline behaviors in order,
-    /// and finally the request handler.
-    /// </summary>
-    /// <typeparam name="TRequest">The request type.</typeparam>
-    /// <param name="request">The request instance to handle.</param>
-    /// <param name="handler">The handler to execute at the end of the pipeline.</param>
-    /// <param name="behaviors">The pipeline behaviors to apply around the handler.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    public static Task ExecuteWithPipeline<TRequest>(
-        TRequest request,
-        IRequestHandler<TRequest> handler,
-        IEnumerable<IRequestPipelineBehavior<TRequest>> behaviors)
-        where TRequest : IRequest
-    {
-        var pipeline = () => handler.HandleAsync(request);
-
-        foreach (var behavior in behaviors.Reverse())
-        {
-            var next = pipeline;
-            pipeline = () => behavior.HandleAsync(request, next);
-        }
-
-        return pipeline();
-    }
-
-    /// <summary>
     /// Executes a request with response, invoking the pipeline behaviors in order,
     /// and finally the request handler.
     /// </summary>

--- a/src/Mediary/Pipeline/IRequestPipelineBehavior.cs
+++ b/src/Mediary/Pipeline/IRequestPipelineBehavior.cs
@@ -3,23 +3,6 @@
 namespace Mediary.Pipeline;
 
 /// <summary>
-/// Defines a pipeline behavior that wraps the handling of a request without a response.
-/// This can be used for cross-cutting concerns like logging, validation, or transactions.
-/// </summary>
-/// <typeparam name="TRequest">The type of the request being handled.</typeparam>
-public interface IRequestPipelineBehavior<TRequest>
-    where TRequest : IRequest
-{
-    /// <summary>
-    /// Handles the behavior logic and invokes the next delegate in the pipeline.
-    /// </summary>
-    /// <param name="request">The request to process.</param>
-    /// <param name="next">A delegate representing the next step in the pipeline.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    public Task HandleAsync(TRequest request, Func<Task> next);
-}
-
-/// <summary>
 /// Defines a pipeline behavior that wraps the handling of a request with a response.
 /// This can be used for cross-cutting concerns like logging, validation, caching, etc.
 /// </summary>


### PR DESCRIPTION
Refactor and Add Semantic Result Types
- Removed IRequest (non-generic) and related interfaces and extensions.
- Unified request handling under IRequest<TResponse>.
- Simplified IRequestDispatcher to a single DispatchAsync method.
- Added semantic result types: Unit, Success, Created, Updated, Deleted.
- Included static Result helper for easier usage.
- Added unit tests to ensure 100% coverage for all new types.